### PR TITLE
Changed handling of related posts on gamepage.

### DIFF
--- a/_layouts/game.html
+++ b/_layouts/game.html
@@ -6,12 +6,23 @@ layout: default
   <div class="post-content__body">
     <h1>{{ page.title }}</h1>
     {{ content }}
-    <hr>
-    <h3>Related posts</h3>
+
+    {% comment %}Build related posts array{% endcomment %}
+    {% assign related_posts = "" | split:"|"  %}
     {% for tags in page.tags %}
     {% assign t = tags %}
     {% for post in site.posts %}
-      {% if post.tags contains t %}
+    {% if post.tags contains t %}
+    {% assign related_posts = related_posts | push: post %}
+    {% endif %}
+    {% endfor %}
+    {% endfor %}
+    {% comment %}End building related posts array{% endcomment %}
+
+    {% if related_posts != empty %}
+    <hr>
+    <h3>Related posts</h3>
+    {% for post in related_posts %}
       <article class="related-post">
         <h4><a class="related-post__title" href="{{ post.url }}">{{ post.title }}</a></h4>
         <ul class="related-post__meta">
@@ -19,9 +30,9 @@ layout: default
           <li>{{ post.date | date: '%d %B %Y' }}</li>
         </ul>
       </article>
-      {% endif %}
     {% endfor %}
-    {% endfor %}
+    {% endif %}
+
   </div>
   <div class="post-content__meta">
     <img class="game-info__boxart" src="{{ page.boxart }}" alt="" />

--- a/_layouts/game.html
+++ b/_layouts/game.html
@@ -8,15 +8,15 @@ layout: default
     {{ content }}
 
     {% comment %}Build related posts array{% endcomment %}
-    {% assign related_posts = "" | split:"|"  %}
-    {% for tags in page.tags %}
-    {% assign t = tags %}
-    {% for post in site.posts %}
-    {% if post.tags contains t %}
-    {% assign related_posts = related_posts | push: post %}
-    {% endif %}
-    {% endfor %}
-    {% endfor %}
+      {% assign related_posts = "" | split:"|" %}
+      {% for tags in page.tags %}
+        {% assign t = tags %}
+        {% for post in site.posts %}
+          {% if post.tags contains t %}
+            {% assign related_posts = related_posts | push: post %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
     {% comment %}End building related posts array{% endcomment %}
 
     {% if related_posts != empty %}


### PR DESCRIPTION
Behaviour has only changed minimally: if there are no related posts
then the horizontal rule and the header "Related posts" should
now no longer show on any given gamepage.

However, in the background, the way related posts are handled
is different -- all related posts are now added to an array,
so that the looping and checking of tags against posts now only
need happen once, but the information about all the related posts
can be used multiple times without extra cost.

This is what has enabled the hiding of the header.